### PR TITLE
Properly catch unset preferences

### DIFF
--- a/src/lua-scripts/nind_denoise_rl.lua
+++ b/src/lua-scripts/nind_denoise_rl.lua
@@ -80,7 +80,7 @@ local function migrate_pref(key, type, default)
     return dt.preferences.read(MODULE_NAME, key, type)
   end)
 
-  if success then
+  if success and value ~= nil and value ~= "" then
     return value
   end
   return default


### PR DESCRIPTION
With Darktable 5.4.1, when trying to load this script, this error fires:

```
     5.4318 LUA ERROR: dtutils.lua: prequire: 223: Error loading contrib/nind_denoise_rl 
     5.4319 LUA ERROR: dtutils.lua: prequire: 224: Error returned is bad argument #3 to '?' (number expected, got nil) 
     5.4319 LUA ERROR: script_manager.lua: activate: 541: error loading contrib/nind_denoise_rl 
     5.4319 LUA ERROR: script_manager.lua: activate: 542: error message: bad argument #3 to '?' (number expected, got nil) 
```

It seems like some API change made it so `dt.preferences.read` returns empty strings for unset preferences instead of erroring? I'm not 100% sure, but this prevents that from propagating down and causing errors